### PR TITLE
Make use of overrides in config files

### DIFF
--- a/src/blueberrypy/config.py
+++ b/src/blueberrypy/config.py
@@ -90,7 +90,7 @@ class BlueberryPyConfiguration(object):
         bundles_yml_path = os.path.join(config_dir, "bundles.yml")
 
         # A local-only config, which overrides the app.yml values
-        app_overrides_yml_path = os.path.join(config_dir, "app.overrides.yml")
+        app_override_yml_path = os.path.join(config_dir, "app.override.yml")
 
         if os.path.exists(app_yml_path):
             config_file_paths["app_yml"] = app_yml_path
@@ -101,8 +101,8 @@ class BlueberryPyConfiguration(object):
         if os.path.exists(bundles_yml_path):
             config_file_paths["bundles_yml"] = bundles_yml_path
 
-        if os.path.exists(app_overrides_yml_path):
-            config_file_paths["app_overrides_yml"] = app_overrides_yml_path
+        if os.path.exists(app_override_yml_path):
+            config_file_paths["app_override_yml"] = app_override_yml_path
 
         self._config_file_paths = config_file_paths
 
@@ -111,15 +111,15 @@ class BlueberryPyConfiguration(object):
                 self._app_config = load(app_yml, Loader)
 
             # If the overrides file exists, override the app config values
-            # with ones from app.overrides.yml
-            if "app_overrides_yml" in config_file_paths:
-                app_overrides_config = {}
-                with open(config_file_paths["app_overrides_yml"]) as app_overrides_yml:
-                    app_overrides_config = load(app_overrides_yml, Loader)
+            # with ones from app.override.yml
+            if "app_override_yml" in config_file_paths:
+                app_override_config = {}
+                with open(config_file_paths["app_override_yml"]) as app_override_yml:
+                    app_override_config = load(app_override_yml, Loader)
 
                 self._app_config = self.__class__.merge_dicts(
                     self._app_config, 
-                    app_overrides_config
+                    app_override_config
                 )
 
         if "logging_yml" in config_file_paths and not logging_config:

--- a/src/blueberrypy/config.py
+++ b/src/blueberrypy/config.py
@@ -89,6 +89,9 @@ class BlueberryPyConfiguration(object):
         logging_yml_path = os.path.join(config_dir, "logging.yml")
         bundles_yml_path = os.path.join(config_dir, "bundles.yml")
 
+        # A local-only config, which overrides the app.yml values
+        app_local_yml_path = os.path.join(config_dir, "app.local.yml")
+
         if os.path.exists(app_yml_path):
             config_file_paths["app_yml"] = app_yml_path
 
@@ -98,11 +101,24 @@ class BlueberryPyConfiguration(object):
         if os.path.exists(bundles_yml_path):
             config_file_paths["bundles_yml"] = bundles_yml_path
 
+        if os.path.exists(app_local_yml_path):
+            config_file_paths["app_local_yml"] = app_local_yml_path
+
         self._config_file_paths = config_file_paths
 
         if "app_yml" in config_file_paths and not app_config:
             with open(config_file_paths["app_yml"]) as app_yml:
                 self._app_config = load(app_yml, Loader)
+
+        # If config is not provided explicitly via app_config variable 
+        # and the overrides file exists, override the app config values
+        # with ones from app.local.yml
+        if "app_local_yml" in config_file_paths and not app_config:
+            app_local_config = {}
+            with open(config_file_paths["app_local_yml"]) as app_local_yml:
+                app_local_config = load(app_local_yml, Loader)
+
+            self._app_config = self.__class__.merge_dicts(self._app_config, app_local_config)
 
         if "logging_yml" in config_file_paths and not logging_config:
             with open(config_file_paths["logging_yml"]) as logging_yml:
@@ -372,22 +388,22 @@ class BlueberryPyConfiguration(object):
         return obj
 
     @classmethod
-    def merge_dicts(cls, app, env):
+    def merge_dicts(cls, base, overrides):
         '''Recursive helper for merging of two dicts'''
-        for k in env.keys():
-            if k in app:
-                if isinstance(app[k], dict) and isinstance(env[k], dict):
-                    app[k] = cls.merge_dicts(app[k], env[k])
-                elif isinstance(env[k], list) and \
-                        not isinstance(app[k], list):
-                    app[k] = [app[k]] + env[k]
-                elif isinstance(app[k], list) and \
-                        not isinstance(env[k], list):
-                    app[k] = app[k] + [env[k]]
-                elif not isinstance(app[k], dict):
-                    app[k] = env[k]
+        for k in overrides.keys():
+            if k in base:
+                if isinstance(base[k], dict) and isinstance(overrides[k], dict):
+                    base[k] = cls.merge_dicts(base[k], overrides[k])
+                elif isinstance(overrides[k], list) and \
+                        not isinstance(base[k], list):
+                    base[k] = [base[k]] + overrides[k]
+                elif isinstance(base[k], list) and \
+                        not isinstance(overrides[k], list):
+                    base[k] = base[k] + [overrides[k]]
+                elif not isinstance(base[k], dict):
+                    base[k] = overrides[k]
                 else:
-                    app[k].update(env[k])
+                    base[k].update(overrides[k])
             else:
-                app[k] = env[k]
-        return app
+                base[k] = overrides[k]
+        return base

--- a/src/blueberrypy/config.py
+++ b/src/blueberrypy/config.py
@@ -90,7 +90,7 @@ class BlueberryPyConfiguration(object):
         bundles_yml_path = os.path.join(config_dir, "bundles.yml")
 
         # A local-only config, which overrides the app.yml values
-        app_local_yml_path = os.path.join(config_dir, "app.local.yml")
+        app_overrides_yml_path = os.path.join(config_dir, "app.overrides.yml")
 
         if os.path.exists(app_yml_path):
             config_file_paths["app_yml"] = app_yml_path
@@ -101,8 +101,8 @@ class BlueberryPyConfiguration(object):
         if os.path.exists(bundles_yml_path):
             config_file_paths["bundles_yml"] = bundles_yml_path
 
-        if os.path.exists(app_local_yml_path):
-            config_file_paths["app_local_yml"] = app_local_yml_path
+        if os.path.exists(app_overrides_yml_path):
+            config_file_paths["app_overrides_yml"] = app_overrides_yml_path
 
         self._config_file_paths = config_file_paths
 
@@ -110,15 +110,17 @@ class BlueberryPyConfiguration(object):
             with open(config_file_paths["app_yml"]) as app_yml:
                 self._app_config = load(app_yml, Loader)
 
-        # If config is not provided explicitly via app_config variable 
-        # and the overrides file exists, override the app config values
-        # with ones from app.local.yml
-        if "app_local_yml" in config_file_paths and not app_config:
-            app_local_config = {}
-            with open(config_file_paths["app_local_yml"]) as app_local_yml:
-                app_local_config = load(app_local_yml, Loader)
+            # If the overrides file exists, override the app config values
+            # with ones from app.overrides.yml
+            if "app_overrides_yml" in config_file_paths:
+                app_overrides_config = {}
+                with open(config_file_paths["app_overrides_yml"]) as app_overrides_yml:
+                    app_overrides_config = load(app_overrides_yml, Loader)
 
-            self._app_config = self.__class__.merge_dicts(self._app_config, app_local_config)
+                self._app_config = self.__class__.merge_dicts(
+                    self._app_config, 
+                    app_overrides_config
+                )
 
         if "logging_yml" in config_file_paths and not logging_config:
             with open(config_file_paths["logging_yml"]) as logging_yml:

--- a/src/blueberrypy/tests/test_config.py
+++ b/src/blueberrypy/tests/test_config.py
@@ -5,7 +5,11 @@ import warnings
 
 from functools import partial
 from StringIO import StringIO
-from unittest import mock
+try:
+    from unittest import mock
+except ImportError:
+    # fallback for old python
+    import mock
 
 from jinja2.loaders import DictLoader
 from webassets import Environment

--- a/src/blueberrypy/tests/test_config.py
+++ b/src/blueberrypy/tests/test_config.py
@@ -283,7 +283,7 @@ class BlueberryPyConfigurationTest(unittest.TestCase):
 
     @mock.patch('os.path.exists', get_dummy_exists([
         '/tmp/dev/app.yml', '/tmp/dev/bundles.yml', '/tmp/dev/logging.yml',
-        '/tmp/dev/app.overrides.yml',
+        '/tmp/dev/app.override.yml',
     ]))
     @mock.patch('builtins.open', get_dummy_open({
         '/tmp/dev/app.yml': [
@@ -293,7 +293,7 @@ class BlueberryPyConfigurationTest(unittest.TestCase):
             value2: value2
             """),
         ],
-        '/tmp/dev/app.overrides.yml': [
+        '/tmp/dev/app.override.yml': [
             textwrap.dedent("""
             value1: new value1
             """),
@@ -307,5 +307,5 @@ class BlueberryPyConfigurationTest(unittest.TestCase):
     )
     def test_config_overrides_file(self):
         config = BlueberryPyConfiguration(config_dir="/tmp")
-        self.assertEqual(config.app_config['value1'], 'new value1')
-        self.assertEqual(config.app_config['value2'], 'value2')
+        self.assertEqual('new value1', config.app_config['value1'])
+        self.assertEqual('value2', config.app_config['value2'])

--- a/src/blueberrypy/tests/test_config.py
+++ b/src/blueberrypy/tests/test_config.py
@@ -103,7 +103,7 @@ class BlueberryPyConfigurationTest(unittest.TestCase):
     }))
     @mock.patch(
         'blueberrypy.config.BlueberryPyConfiguration.validate', 
-        (lambda self: None),
+        lambda self: None,
     )
     def test_config_file_paths(self):
         config = BlueberryPyConfiguration(config_dir="/tmp")
@@ -307,7 +307,7 @@ class BlueberryPyConfigurationTest(unittest.TestCase):
     }))
     @mock.patch(
         'blueberrypy.config.BlueberryPyConfiguration.validate', 
-        (lambda self: None),
+        lambda self: None,
     )
     def test_config_overrides_file(self):
         config = BlueberryPyConfiguration(config_dir="/tmp")

--- a/src/blueberrypy/tests/test_config.py
+++ b/src/blueberrypy/tests/test_config.py
@@ -5,6 +5,7 @@ import warnings
 
 from functools import partial
 from StringIO import StringIO
+from unittest import mock
 
 from jinja2.loaders import DictLoader
 from webassets import Environment
@@ -33,6 +34,30 @@ rest_controller = cherrypy.dispatch.RoutesDispatcher()
 rest_controller.connect("dummy", "/dummy", DummyRestController, action="dummy")
 
 
+def get_dummy_exists(paths):
+    from os.path import exists as real_exists
+    def proxied_exists(path):
+        if path in paths:
+            return True
+        return real_exists(path)
+    return proxied_exists
+
+
+def get_dummy_open(config):
+    class FakeFile(StringIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type=None, exc_value=None, traceback=None):
+            return False
+    real_open = builtins.open
+    def proxied_open(filename, mode='r', buffering=1):
+        if filename in config:
+            return FakeFile(*config[filename])
+        return real_open(filename, mode, buffering)
+    return proxied_open
+
+
 class BlueberryPyConfigurationTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         self.assertRaisesRegex = getattr(self, "assertRaisesRegex",
@@ -55,61 +80,34 @@ class BlueberryPyConfigurationTest(unittest.TestCase):
             "BlueberryPy application configuration not found."):
                 BlueberryPyConfiguration()
 
+    @mock.patch('os.path.exists', get_dummy_exists([
+        '/tmp/dev/app.yml', '/tmp/dev/bundles.yml', '/tmp/dev/logging.yml',
+    ]))
+    @mock.patch('builtins.open', get_dummy_open({
+        '/tmp/dev/app.yml': [
+            textwrap.dedent("""
+            controllers: []
+            """),
+        ],
+        '/tmp/dev/bundles.yml': [
+            textwrap.dedent("""
+            directory: /tmp
+            url: /
+            """),
+        ],
+        '/tmp/dev/logging.yml': [],
+    }))
+    @mock.patch(
+        'blueberrypy.config.BlueberryPyConfiguration.validate', 
+        (lambda self: None),
+    )
     def test_config_file_paths(self):
-        # stub out os.path.exists
-        import os.path
-        old_exists = os.path.exists
-
-        def proxied_exists(path):
-            if path == "/tmp/dev/app.yml":
-                return True
-            elif path == "/tmp/dev/bundles.yml":
-                return True
-            elif path == "/tmp/dev/logging.yml":
-                return True
-            return old_exists(path)
-        os.path.exists = proxied_exists
-        old_open = builtins.open
-
-        # stub out open
-        class FakeFile(StringIO):
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type=None, exc_value=None, traceback=None):
-                return False
-
-        def proxied_open(filename, mode='r', buffering=1):
-            if filename == "/tmp/dev/app.yml":
-                return FakeFile(textwrap.dedent("""
-                controllers: []
-                """))
-            elif filename == "/tmp/dev/bundles.yml":
-                return FakeFile(textwrap.dedent("""
-                directory: /tmp
-                url: /
-                """))
-            elif filename == "/tmp/dev/logging.yml":
-                return FakeFile()
-            else:
-                return old_open(filename, mode, buffering)
-        builtins.open = proxied_open
-
-        # stub out validate()
-        old_validate = BlueberryPyConfiguration.validate
-        BlueberryPyConfiguration.validate = lambda self: None
-
-        try:
-            config = BlueberryPyConfiguration(config_dir="/tmp")
-            config_file_paths = config.config_file_paths
-            self.assertEqual(len(config_file_paths), 3)
-            self.assertEqual(config_file_paths[0], "/tmp/dev/app.yml")
-            self.assertEqual(config_file_paths[1], "/tmp/dev/bundles.yml")
-            self.assertEqual(config_file_paths[2], "/tmp/dev/logging.yml")
-        finally:
-            BlueberryPyConfiguration.validate = old_validate
-            os.path.exists = old_exists
-            builtins.open = old_open
+        config = BlueberryPyConfiguration(config_dir="/tmp")
+        config_file_paths = config.config_file_paths
+        self.assertEqual(len(config_file_paths), 3)
+        self.assertEqual(config_file_paths[0], "/tmp/dev/app.yml")
+        self.assertEqual(config_file_paths[1], "/tmp/dev/bundles.yml")
+        self.assertEqual(config_file_paths[2], "/tmp/dev/logging.yml")
 
     def test_use_email(self):
         app_config = self.basic_valid_app_config.copy()
@@ -283,62 +281,31 @@ class BlueberryPyConfigurationTest(unittest.TestCase):
         app_config = {"controllers": {"/api": {"controller": rest_controller}}}
         config = BlueberryPyConfiguration(app_config=app_config)
 
+    @mock.patch('os.path.exists', get_dummy_exists([
+        '/tmp/dev/app.yml', '/tmp/dev/bundles.yml', '/tmp/dev/logging.yml',
+        '/tmp/dev/app.overrides.yml',
+    ]))
+    @mock.patch('builtins.open', get_dummy_open({
+        '/tmp/dev/app.yml': [
+            textwrap.dedent("""
+            controllers: []
+            value1: value1
+            value2: value2
+            """),
+        ],
+        '/tmp/dev/app.overrides.yml': [
+            textwrap.dedent("""
+            value1: new value1
+            """),
+        ],
+        '/tmp/dev/bundles.yml': [],
+        '/tmp/dev/logging.yml': [],
+    }))
+    @mock.patch(
+        'blueberrypy.config.BlueberryPyConfiguration.validate', 
+        (lambda self: None),
+    )
     def test_config_overrides_file(self):
-        # stub out os.path.exists
-        import os.path
-        old_exists = os.path.exists
-
-        def proxied_exists(path):
-            if path == "/tmp/dev/app.yml":
-                return True
-            elif path == "/tmp/dev/bundles.yml":
-                return True
-            elif path == "/tmp/dev/logging.yml":
-                return True
-            elif path == "/tmp/dev/app.overrides.yml":
-                return True
-            return old_exists(path)
-        os.path.exists = proxied_exists
-        old_open = builtins.open
-
-        # stub out open
-        class FakeFile(StringIO):
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type=None, exc_value=None, traceback=None):
-                return False
-
-        def proxied_open(filename, mode='r', buffering=1):
-            if filename == "/tmp/dev/app.overrides.yml":
-                return FakeFile(textwrap.dedent("""
-                value1: new value1
-                """))
-            if filename == "/tmp/dev/app.yml":
-                return FakeFile(textwrap.dedent("""
-                value1: value1
-                value2: value2
-                """))
-            elif filename == "/tmp/dev/bundles.yml":
-                return FakeFile(textwrap.dedent("""
-                directory: /tmp
-                url: /
-                """))
-            elif filename == "/tmp/dev/logging.yml":
-                return FakeFile()
-            else:
-                return old_open(filename, mode, buffering)
-        builtins.open = proxied_open
-
-        # stub out validate()
-        old_validate = BlueberryPyConfiguration.validate
-        BlueberryPyConfiguration.validate = lambda self: None
-
-        try:
-            config = BlueberryPyConfiguration(config_dir="/tmp")
-            self.assertEqual(config.app_config['value1'], 'new value1')
-            self.assertEqual(config.app_config['value2'], 'value2')
-        finally:
-            BlueberryPyConfiguration.validate = old_validate
-            os.path.exists = old_exists
-            builtins.open = old_open
+        config = BlueberryPyConfiguration(config_dir="/tmp")
+        self.assertEqual(config.app_config['value1'], 'new value1')
+        self.assertEqual(config.app_config['value2'], 'value2')


### PR DESCRIPTION
Modify config creation so it can handle local overrides stored in
config_dir/app.local.yml
If such file exists and config has not been provided explicitly, the
file is read and its contents override contents of app.yml file.

You can store crucial data such as db login and password in
app.local.yml file and add file to .gitignore, so the main configuration
will be in repo and your precious credentials will be saved only locally
