### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Project specific generated files
+test.cfg
+doc/_build
+.coverage
+cover
+.tox
+
+# Python temp files
+*.pyc
+*.pyo
+*.egg-info
+EGG-INFO
+*.egg
+
+# Editor generated metadata files
+.ropeproject
+.project
+.pydevproject
+.settings
+bpython.desktop
+*sublime-*
+
+# virtualenv and distutils files
+build
+temp
+dist
+MANIFEST
+.Python
+bin
+lib
+include
+man


### PR DESCRIPTION
The migration from mercurial to git took place, hence .hgignore do not
work anymore. Still it may be used somewhere.

Create a .gitignore file with the contents similar to .hgignore
