### PR TITLE
Make tox env be created errorless again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ speedup_requires = ["hiredis>=0.1.0",
                     "m3-cdecimal>=2.3",
                     "simplejson>=3.4"]
 
-dev_requires = ["Sphinx>=1.2",
+dev_requires = ["Sphinx>=1.2,<1.5",
                 "nose>=1.3",
                 "nose-testconfig>=0.9",
                 "coverage>=3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps = -rrequirements.txt
     openstack.nose-plugin
 
 [testenv]
-install_command = pip install --no-use-wheel --pre {opts} {packages}
+install_command = pip install --no-use-wheel {opts} {packages}
 deps = {[base]deps}
 changedir = {envdir}
 commands = {envbindir}/nosetests --config={toxinidir}/setup.cfg --tc-file={toxinidir}/setup.cfg {envsitepackagesdir}/blueberrypy/tests/
@@ -23,7 +23,6 @@ deps = {[base]deps}
        psycopg2cffi
 
 [testenv:py27]
-install_command = pip install --no-use-wheel --pre {opts} {packages}
 deps = {[base]deps}
        mock
        hiredis


### PR DESCRIPTION
- Cleanup tox.ini -- remove duplicate install_command from descendant testenv
- Use stable versions of packages when testing